### PR TITLE
Improve pydoc output.

### DIFF
--- a/python/lib/indent.py
+++ b/python/lib/indent.py
@@ -1,5 +1,8 @@
 """ Indent - Implement text indentation.  Useful for pretty printing. """
 
+# Tell pydoc to only document these classes:
+__all__ = [ 'Indent' ]
+
 class Indent:
     def __init__(self, spaces = 4):
         self._spaces = ' ' * spaces

--- a/python/lib/network.py
+++ b/python/lib/network.py
@@ -1,3 +1,8 @@
+""" Basic UDP send/receive and TCP/IP client/server classes. """
+
+# Tell pydoc to only document these classes:
+__all__ = [ 'UdpReceiver', 'UdpSender', 'TcpServer', 'TcpClient' ]
+
 import socket
 
 class UdpReceiver:

--- a/python/lib/reutil.py
+++ b/python/lib/reutil.py
@@ -1,5 +1,8 @@
 """ reutil - Regular expression utilities. """
 
+# Tell pydoc to only document these functions:
+__all__ = [ 'multiple_replace' ]
+
 import re
 
 def multiple_replace(text, adict):

--- a/python/lib/time.py
+++ b/python/lib/time.py
@@ -1,7 +1,12 @@
+""" Convenient time handling functions. """
+
+# Tell pydoc to only document these functions:
+__all__ = [ 'to_military_time' ]
+
 from datetime import datetime
 
-""" Converts hours/minutes am/pm to millitary time. """
 def to_military_time(x):
+    """ Converts hours/minutes am/pm to millitary time. """
     return datetime.strptime(x, "%I:%M %p").strftime("%H:%M")
 
 import unittest
@@ -57,7 +62,7 @@ class TestToMilitaryTime(unittest.TestCase):
         for h in lib.util.range_inclusive(0, 23):
             for m in lib.util.range_inclusive(0, 59):
                 # Military time.
-                tm   = f'{h:02d}:{m:02d}'
+                tm = f'{h:02d}:{m:02d}'
                 h12 = h
                 if h <= 11:
                     apm = 'am'

--- a/python/lib/util.py
+++ b/python/lib/util.py
@@ -1,5 +1,11 @@
-""" Yields a range that includes the last item. """
+""" Convenient utility functions. """
+
+# Tell pydoc to only document these functions:
+__all__ = [ 'range_inclusive' ]
+
+
 def range_inclusive(*args):
+    """ Yields a range that includes the last item. """
     numargs = len(args)
     if numargs == 0:
         raise TypeError('No argument(s) given.')

--- a/python/lib/xml/domutil.py
+++ b/python/lib/xml/domutil.py
@@ -3,6 +3,10 @@ domutil - XML DOM utilities.  The functions you wish had been included
 in xml.dom.minidom.
 """
 
+# Tell pydoc to only document these functions:
+__all__ = [ 'getChildrenByTagName', 'getNodeText', 'setNodeText' ]
+
+
 import xml.dom.minidom
 
 def getChildrenByTagName(node, tagName):


### PR DESCRIPTION
Prevent pydoc from documenting unit test classes and other imported modules.